### PR TITLE
Use Team type in TeamsTab

### DIFF
--- a/src/components/TeamsTab.tsx
+++ b/src/components/TeamsTab.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
-import { Player, TournamentType } from '../types/tournament';
+import { Player, Team, TournamentType } from '../types/tournament';
 import { Plus, Trash2, Users, Printer } from 'lucide-react';
 
 interface TeamsTabProps {
-  teams: any[];
+  teams: Team[];
   tournamentType: TournamentType;
   onAddTeam: (players: Player[]) => void;
   onRemoveTeam: (teamId: string) => void;


### PR DESCRIPTION
## Summary
- import `Team` in `TeamsTab`
- use `Team[]` for the `teams` prop

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685214336d348324870dda4e274a02c2