### PR TITLE
Add logo component and integrate in header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Trophy, Sun, Moon } from 'lucide-react';
+import { Sun, Moon } from 'lucide-react';
+import { Logo } from './Logo';
 
 interface HeaderProps {
   darkMode: boolean;
@@ -11,8 +12,8 @@ export function Header({ darkMode, onToggleDarkMode }: HeaderProps) {
     <header className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
       <div className="px-6 py-4 flex items-center justify-between">
         <div className="flex items-center space-x-3">
-          <div className="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center">
-            <Trophy className="w-6 h-6 text-white" />
+          <div className="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center overflow-hidden">
+            <Logo className="w-8 h-8" />
           </div>
           <div>
             <h1 className="text-xl font-bold text-gray-900 dark:text-white">

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface LogoProps {
+  className?: string;
+}
+
+export function Logo({ className }: LogoProps) {
+  return (
+    <img src="/logo.png" alt="Pétanque Manager" className={className} />
+  );
+}

--- a/src/components/TournamentSetup.tsx
+++ b/src/components/TournamentSetup.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { TournamentType } from '../types/tournament';
-import { Trophy, Users, Target } from 'lucide-react';
+import { Users, Target, Trophy } from 'lucide-react';
+import { Logo } from './Logo';
 
 interface TournamentSetupProps {
   onCreateTournament: (name: string, type: TournamentType, courts: number) => void;
@@ -30,8 +31,8 @@ export function TournamentSetup({ onCreateTournament }: TournamentSetupProps) {
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-4">
       <div className="max-w-2xl w-full">
         <div className="text-center mb-8">
-          <div className="w-16 h-16 bg-blue-600 rounded-full flex items-center justify-center mx-auto mb-4">
-            <Trophy className="w-8 h-8 text-white" />
+          <div className="w-16 h-16 bg-blue-600 rounded-full flex items-center justify-center mx-auto mb-4 overflow-hidden">
+            <Logo className="w-12 h-12" />
           </div>
           <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
             Nouveau Tournoi de Pétanque


### PR DESCRIPTION
## Summary
- add reusable `Logo` component
- display logo in header instead of trophy icon
- show logo on tournament setup screen

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685218d2f2d48324bbbdcad96fbfebf5