### PR TITLE
Fix logo asset for print views

### DIFF
--- a/public/logo.png
+++ b/public/logo.png
@@ -1,1 +1,0 @@
-[Binary file content - Logo Pétanque Manager]

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -6,6 +6,6 @@ interface LogoProps {
 
 export function Logo({ className }: LogoProps) {
   return (
-    <img src="/logo.png" alt="Pétanque Manager" className={className} />
+    <img src="/petanque-icon.svg" alt="Pétanque Manager" className={className} />
   );
 }

--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -134,7 +134,7 @@ export function MatchesTab({
         </head>
         <body>
           <div class="header">
-            <img src="/logo.png" alt="Pétanque Manager" class="logo" />
+            <img src="/petanque-icon.svg" alt="Pétanque Manager" class="logo" />
             <h1>🏆 Matchs - Tour ${round}</h1>
             <p>Tournoi de Pétanque - ${new Date().toLocaleDateString('fr-FR')}</p>
           </div>

--- a/src/components/StandingsTab.tsx
+++ b/src/components/StandingsTab.tsx
@@ -116,7 +116,7 @@ export function StandingsTab({ teams }: StandingsTabProps) {
         </head>
         <body>
           <div class="header">
-            <img src="/logo.png" alt="Pétanque Manager" class="logo" />
+            <img src="/petanque-icon.svg" alt="Pétanque Manager" class="logo" />
             <h1>🏆 Classement Final</h1>
             <p>Tournoi de Pétanque - ${new Date().toLocaleDateString('fr-FR')}</p>
           </div>

--- a/src/components/TeamsTab.tsx
+++ b/src/components/TeamsTab.tsx
@@ -139,7 +139,7 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam }: Tea
         </head>
         <body>
           <div class="header">
-            <img src="/logo.png" alt="Pétanque Manager" class="logo" />
+            <img src="/petanque-icon.svg" alt="Pétanque Manager" class="logo" />
             <h1>🏆 Liste des Équipes</h1>
             <p>Tournoi de Pétanque - ${new Date().toLocaleDateString('fr-FR')}</p>
           </div>


### PR DESCRIPTION
## Summary
- use `petanque-icon.svg` instead of broken `logo.png`
- clean up references in print views

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68521fd4c4f88324b69de8639a27cc36