### PR TITLE
Update app logo references

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/petanque-icon.svg" />
+    <link rel="icon" type="image/png" href="/logo1.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pétanque Manager - Gestionnaire de Tournois</title>
   </head>

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -6,6 +6,6 @@ interface LogoProps {
 
 export function Logo({ className }: LogoProps) {
   return (
-    <img src="/petanque-icon.svg" alt="Pétanque Manager" className={className} />
+    <img src="/logo1.png" alt="Pétanque Manager" className={className} />
   );
 }

--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -134,7 +134,7 @@ export function MatchesTab({
         </head>
         <body>
           <div class="header">
-            <img src="/petanque-icon.svg" alt="Pétanque Manager" class="logo" />
+            <img src="/logo1.png" alt="Pétanque Manager" class="logo" />
             <h1>🏆 Matchs - Tour ${round}</h1>
             <p>Tournoi de Pétanque - ${new Date().toLocaleDateString('fr-FR')}</p>
           </div>

--- a/src/components/StandingsTab.tsx
+++ b/src/components/StandingsTab.tsx
@@ -116,7 +116,7 @@ export function StandingsTab({ teams }: StandingsTabProps) {
         </head>
         <body>
           <div class="header">
-            <img src="/petanque-icon.svg" alt="Pétanque Manager" class="logo" />
+            <img src="/logo1.png" alt="Pétanque Manager" class="logo" />
             <h1>🏆 Classement Final</h1>
             <p>Tournoi de Pétanque - ${new Date().toLocaleDateString('fr-FR')}</p>
           </div>

--- a/src/components/TeamsTab.tsx
+++ b/src/components/TeamsTab.tsx
@@ -139,7 +139,7 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam }: Tea
         </head>
         <body>
           <div class="header">
-            <img src="/petanque-icon.svg" alt="Pétanque Manager" class="logo" />
+            <img src="/logo1.png" alt="Pétanque Manager" class="logo" />
             <h1>🏆 Liste des Équipes</h1>
             <p>Tournoi de Pétanque - ${new Date().toLocaleDateString('fr-FR')}</p>
           </div>


### PR DESCRIPTION
## Summary
- use `logo1.png` as the favicon
- update logo component to use `logo1.png`
- update print templates to reference `logo1.png`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68522ba42bc8832485eb7003ca33f582