### PR TITLE
Support waiting matches when courts are full

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,6 +90,7 @@ function App() {
               matches={tournament.matches}
               teams={tournament.teams}
               currentRound={tournament.currentRound}
+              courts={tournament.courts}
               onGenerateRound={generateRound}
               onUpdateScore={updateMatchScore}
               onUpdateCourt={updateMatchCourt}

--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -6,18 +6,20 @@ interface MatchesTabProps {
   matches: Match[];
   teams: Team[];
   currentRound: number;
+  courts: number;
   onGenerateRound: () => void;
   onUpdateScore: (matchId: string, team1Score: number, team2Score: number) => void;
   onUpdateCourt: (matchId: string, court: number) => void;
 }
 
-export function MatchesTab({ 
-  matches, 
-  teams, 
-  currentRound, 
-  onGenerateRound, 
+export function MatchesTab({
+  matches,
+  teams,
+  currentRound,
+  courts,
+  onGenerateRound,
   onUpdateScore,
-  onUpdateCourt 
+  onUpdateCourt
 }: MatchesTabProps) {
   const [editingMatch, setEditingMatch] = useState<string | null>(null);
   const [editScores, setEditScores] = useState<{ team1: number; team2: number }>({ team1: 0, team2: 0 });
@@ -155,7 +157,7 @@ export function MatchesTab({
             <tbody>
               ${roundMatches.map(match => `
                 <tr>
-                  <td>${match.isBye ? '-' : match.court}</td>
+                  <td>${match.isBye ? '-' : (match.court <= courts ? match.court : 'Libre ' + (match.court - courts))}</td>
                   <td>
                     ${getTeamName(match.team1Id)}<br/>
                     <small>${getTeamPlayers(match.team1Id)}</small>
@@ -274,15 +276,28 @@ export function MatchesTab({
                         ) : (
                           <div className="flex items-center space-x-1">
                             <MapPin className="w-4 h-4 text-gray-400" />
-                            <select
-                              value={match.court}
-                              onChange={(e) => onUpdateCourt(match.id, Number(e.target.value))}
-                              className="text-sm border-0 bg-transparent text-gray-900 dark:text-white focus:ring-0"
-                            >
-                              {Array.from({ length: 10 }, (_, i) => i + 1).map(court => (
-                                <option key={court} value={court}>{court}</option>
-                              ))}
-                            </select>
+                            {match.court > courts ? (
+                              <select
+                                value={match.court}
+                                onChange={(e) => onUpdateCourt(match.id, Number(e.target.value))}
+                                className="text-sm border-0 bg-transparent text-gray-900 dark:text-white focus:ring-0"
+                              >
+                                <option value={match.court}>{`Libre ${match.court - courts}`}</option>
+                                {Array.from({ length: 10 }, (_, i) => i + 1).map(court => (
+                                  <option key={court} value={court}>{court}</option>
+                                ))}
+                              </select>
+                            ) : (
+                              <select
+                                value={match.court}
+                                onChange={(e) => onUpdateCourt(match.id, Number(e.target.value))}
+                                className="text-sm border-0 bg-transparent text-gray-900 dark:text-white focus:ring-0"
+                              >
+                                {Array.from({ length: 10 }, (_, i) => i + 1).map(court => (
+                                  <option key={court} value={court}>{court}</option>
+                                ))}
+                              </select>
+                            )}
                           </div>
                         )}
                       </td>

--- a/src/utils/matchmaking.ts
+++ b/src/utils/matchmaking.ts
@@ -147,31 +147,31 @@ function generateQuadretteMatches(tournament: Tournament): Match[] {
 }
 
 function generateMeleeMatches(tournament: Tournament): Match[] {
-  const { teams, currentRound, courts } = tournament;
+  const { teams, currentRound } = tournament;
   const round = currentRound + 1;
-  
+
   // Shuffle teams randomly for mêlée
   const shuffledTeams = [...teams].sort(() => Math.random() - 0.5);
   const newMatches: Match[] = [];
 
-  // Create matches for available courts
   let courtIndex = 1;
-  for (let i = 0; i < shuffledTeams.length - 1 && courtIndex <= courts; i += 2) {
+  for (let i = 0; i < shuffledTeams.length - 1; i += 2) {
     const team1 = shuffledTeams[i];
     const team2 = shuffledTeams[i + 1];
 
-    if (team2) {
-      newMatches.push({
-        id: crypto.randomUUID(),
-        round,
-        court: courtIndex,
-        team1Id: team1.id,
-        team2Id: team2.id,
-        completed: false,
-        isBye: false,
-      });
-      courtIndex++;
-    }
+    if (!team2) continue;
+
+    newMatches.push({
+      id: crypto.randomUUID(),
+      round,
+      court: courtIndex,
+      team1Id: team1.id,
+      team2Id: team2.id,
+      completed: false,
+      isBye: false,
+    });
+
+    courtIndex++;
   }
 
   return newMatches;


### PR DESCRIPTION
## Summary
- generate melee matches for all teams even when courts are limited
- pass `courts` prop to `MatchesTab`
- show matches exceeding available courts as `Libre N` and allow assigning a court

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68522efdd2c88324a72b3e58ed5f0194