### PR TITLE
Support melee group matches

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -38,6 +38,14 @@ export function MatchesTab({
       .join(', ');
   };
 
+  const getGroupLabel = (ids: string[]) => {
+    const names = ids.map(id => {
+      const team = teams.find(t => t.id === id);
+      return team?.players[0]?.name || 'Inconnu';
+    });
+    return names.join(' + ');
+  };
+
   const handleEditScore = (match: Match) => {
     setEditingMatch(match.id);
     setEditScores({
@@ -159,12 +167,12 @@ export function MatchesTab({
                 <tr>
                   <td>${match.isBye ? '-' : (match.court <= courts ? match.court : 'Libre ' + (match.court - courts))}</td>
                   <td>
-                    ${getTeamName(match.team1Id)}<br/>
-                    <small>${getTeamPlayers(match.team1Id)}</small>
+                    ${match.team1Ids ? getGroupLabel(match.team1Ids) : getTeamName(match.team1Id)}
+                    ${!match.team1Ids ? `<br/><small>${getTeamPlayers(match.team1Id)}</small>` : ''}
                   </td>
                   <td class="score">${match.completed || match.isBye ? `${match.team1Score} - ${match.team2Score}` : '- - -'}</td>
                   <td>
-                    ${match.isBye ? 'BYE' : `${getTeamName(match.team2Id)}<br/><small>${getTeamPlayers(match.team2Id)}</small>`}
+                    ${match.isBye ? 'BYE' : match.team2Ids ? getGroupLabel(match.team2Ids) : `${getTeamName(match.team2Id)}<br/><small>${getTeamPlayers(match.team2Id)}</small>`}
                   </td>
                   <td class="${match.completed || match.isBye ? 'status-completed' : 'status-pending'}">
                     ${match.completed || match.isBye ? 'Terminé' : 'En cours'}
@@ -302,10 +310,16 @@ export function MatchesTab({
                         )}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
-                        {getTeamName(match.team1Id)}
-                        <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                          {getTeamPlayers(match.team1Id)}
-                        </div>
+                        {match.team1Ids ? (
+                          getGroupLabel(match.team1Ids)
+                        ) : (
+                          <>
+                            {getTeamName(match.team1Id)}
+                            <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                              {getTeamPlayers(match.team1Id)}
+                            </div>
+                          </>
+                        )}
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-center">
                         {editingMatch === match.id ? (
@@ -337,6 +351,8 @@ export function MatchesTab({
                       <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
                         {match.isBye ? (
                           <span className="text-gray-500 dark:text-gray-400 italic">BYE</span>
+                        ) : match.team2Ids ? (
+                          getGroupLabel(match.team2Ids)
                         ) : (
                           <>
                             {getTeamName(match.team2Id)}

--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -105,7 +105,14 @@ export function useTournament() {
     // Update team statistics
     const updatedTeams = tournament.teams.map(team => {
       const teamMatches = updatedMatches.filter(
-        match => (match.team1Id === team.id || match.team2Id === team.id) && match.completed
+        match =>
+          match.completed &&
+          (
+            match.team1Id === team.id ||
+            match.team2Id === team.id ||
+            (match.team1Ids && match.team1Ids.includes(team.id)) ||
+            (match.team2Ids && match.team2Ids.includes(team.id))
+          )
       );
 
       let wins = 0;
@@ -118,7 +125,13 @@ export function useTournament() {
           wins += 1;
           pointsFor += 13;
           pointsAgainst += 7;
-        } else if (match.team1Id === team.id) {
+          return;
+        }
+
+        const isTeam1 = match.team1Id === team.id || (match.team1Ids && match.team1Ids.includes(team.id));
+        const isTeam2 = match.team2Id === team.id || (match.team2Ids && match.team2Ids.includes(team.id));
+
+        if (isTeam1) {
           pointsFor += match.team1Score || 0;
           pointsAgainst += match.team2Score || 0;
           if ((match.team1Score || 0) > (match.team2Score || 0)) {
@@ -126,7 +139,7 @@ export function useTournament() {
           } else {
             losses += 1;
           }
-        } else if (match.team2Id === team.id) {
+        } else if (isTeam2) {
           pointsFor += match.team2Score || 0;
           pointsAgainst += match.team1Score || 0;
           if ((match.team2Score || 0) > (match.team1Score || 0)) {

--- a/src/types/tournament.ts
+++ b/src/types/tournament.ts
@@ -23,6 +23,14 @@ export interface Match {
   court: number;
   team1Id: string;
   team2Id: string;
+  /**
+   * When matches are generated for formats that group players on the fly
+   * (such as "mêlée"), the player identifiers for each side are stored in
+   * these arrays. They remain optional so that standard formats using
+   * permanent teams can continue relying on `team1Id` and `team2Id` only.
+   */
+  team1Ids?: string[];
+  team2Ids?: string[];
   team1Score?: number;
   team2Score?: number;
   completed: boolean;


### PR DESCRIPTION
## Summary
- extend `Match` interface with `team1Ids` and `team2Ids`
- generate melee matches by grouping players and allowing waiting courts
- update score calculations for grouped players
- display grouped player names in matches
- install npm deps and run linter

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852383fdb488324814a46b1d48d70e4