### PR TITLE
Enhance mêlée player labeling

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -39,11 +39,11 @@ export function MatchesTab({
   };
 
   const getGroupLabel = (ids: string[]) => {
-    const names = ids.map(id => {
+    const labels = ids.map(id => {
       const team = teams.find(t => t.id === id);
-      return team?.players[0]?.name || 'Inconnu';
+      return team?.name || team?.players[0]?.name || 'Inconnu';
     });
-    return names.join(' + ');
+    return labels.join(' + ');
   };
 
   const handleEditScore = (match: Match) => {

--- a/src/components/TeamsTab.tsx
+++ b/src/components/TeamsTab.tsx
@@ -64,7 +64,7 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam }: Tea
       <!DOCTYPE html>
       <html>
         <head>
-          <title>Liste des Équipes - Pétanque Manager</title>
+          <title>Liste des ${tournamentType === 'melee' ? 'Joueurs' : 'Équipes'} - Pétanque Manager</title>
           <style>
             body { 
               font-family: Arial, sans-serif; 
@@ -140,12 +140,12 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam }: Tea
         <body>
           <div class="header">
             <img src="/logo1.png" alt="Pétanque Manager" class="logo" />
-            <h1>🏆 Liste des Équipes</h1>
+            <h1>🏆 Liste des ${tournamentType === 'melee' ? 'Joueurs' : 'Équipes'}</h1>
             <p>Tournoi de Pétanque - ${new Date().toLocaleDateString('fr-FR')}</p>
           </div>
           <div class="tournament-info">
-            <strong>Type:</strong> ${tournamentType.charAt(0).toUpperCase() + tournamentType.slice(1)} • 
-            <strong>Nombre d'équipes:</strong> ${teams.length}
+            <strong>Type:</strong> ${tournamentType.charAt(0).toUpperCase() + tournamentType.slice(1)} •
+            <strong>Nombre ${tournamentType === 'melee' ? 'de joueurs' : "d'équipes"}:</strong> ${teams.length}
           </div>
           <div class="team-list">
             ${teams.map(team => `
@@ -282,10 +282,12 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam }: Tea
         <div className="text-center py-12">
           <Users className="w-12 h-12 text-gray-400 mx-auto mb-4" />
           <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
-            Aucune équipe inscrite
+            {tournamentType === 'melee' ? 'Aucun joueur inscrit' : 'Aucune équipe inscrite'}
           </h3>
           <p className="text-gray-500 dark:text-gray-400">
-            Commencez par ajouter des équipes pour votre tournoi
+            {tournamentType === 'melee'
+              ? 'Commencez par ajouter des joueurs pour votre tournoi'
+              : 'Commencez par ajouter des équipes pour votre tournoi'}
           </p>
         </div>
       )}

--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -40,9 +40,14 @@ export function useTournament() {
     if (!tournament) return;
 
     const teamNumber = tournament.teams.length + 1;
+    const teamName =
+      tournament.type === 'melee'
+        ? `${teamNumber} - ${players[0].name}`
+        : `Équipe ${teamNumber}`;
+
     const team: Team = {
       id: crypto.randomUUID(),
-      name: `Équipe ${teamNumber}`,
+      name: teamName,
       players,
       wins: 0,
       losses: 0,
@@ -65,7 +70,10 @@ export function useTournament() {
     // Renumber teams
     const renumberedTeams = updatedTeams.map((team, index) => ({
       ...team,
-      name: `Équipe ${index + 1}`,
+      name:
+        tournament.type === 'melee'
+          ? `${index + 1} - ${team.players[0].name}`
+          : `Équipe ${index + 1}`,
     }));
 
     const updatedTournament = {


### PR DESCRIPTION
## Summary
- identify mêlée players by registration order instead of team numbers
- print player list header adaptively
- show message changes when no players are registered
- display player numbers in grouped match labels

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852db423bd883248b7a2d578daf7045