### PR TITLE
Fix duplicate names in solo tournaments

### DIFF
--- a/src/components/TeamsTab.tsx
+++ b/src/components/TeamsTab.tsx
@@ -147,12 +147,16 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam }: Tea
             ${teams.map(team => `
               <div class="team-item">
                 <div class="team-name">${team.name}</div>
-                ${team.players.map((player: Player) => `
-                  <div class="player">
-                    ${player.label ? `<span class="player-label">${player.label}</span>` : ''}
-                    ${player.name}
-                  </div>
-                `).join('')}
+                ${!isSolo
+                  ? team.players
+                      .map((player: Player) => `
+                        <div class="player">
+                          ${player.label ? `<span class="player-label">${player.label}</span>` : ''}
+                          ${player.name}
+                        </div>
+                      `)
+                      .join('')
+                  : ''}
               </div>
             `).join('')}
           </div>
@@ -243,18 +247,23 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam }: Tea
                   <Users className="w-5 h-5 text-blue-600" />
                   <h3 className="font-medium text-gray-900 dark:text-white">{team.name}</h3>
                 </div>
-                <div className="flex flex-wrap gap-x-2 gap-y-1">
-                  {team.players.map((player: Player) => (
-                    <div key={player.id} className="flex items-center space-x-2 text-sm text-gray-600 dark:text-gray-400">
-                      {player.label && (
-                        <span className="w-5 h-5 bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400 rounded-full flex items-center justify-center text-xs font-medium">
-                          {player.label}
-                        </span>
-                      )}
-                      <span>{player.name}</span>
-                    </div>
-                  ))}
-                </div>
+                {!isSolo && (
+                  <div className="flex flex-wrap gap-x-2 gap-y-1">
+                    {team.players.map((player: Player) => (
+                      <div
+                        key={player.id}
+                        className="flex items-center space-x-2 text-sm text-gray-600 dark:text-gray-400"
+                      >
+                        {player.label && (
+                          <span className="w-5 h-5 bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400 rounded-full flex items-center justify-center text-xs font-medium">
+                            {player.label}
+                          </span>
+                        )}
+                        <span>{player.name}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
               <button
                 onClick={() => onRemoveTeam(team.id)}


### PR DESCRIPTION
## Summary
- avoid repeating player names for solo tournaments in TeamsTab
- hide player entries in print view when not needed

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852e3652dd4832485d80f9db24d74f5