### PR TITLE
Simplify printable views

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -84,24 +84,16 @@ export function MatchesTab({
       <!DOCTYPE html>
       <html>
         <head>
-          <title>Matchs Tour ${round} - Pétanque Manager</title>
+          <title>Tour ${round}</title>
           <style>
-            body { 
-              font-family: Arial, sans-serif; 
-              margin: 20px; 
+            body {
+              font-family: Arial, sans-serif;
+              margin: 10px;
               color: #333;
             }
-            .header { 
-              text-align: center; 
-              margin-bottom: 30px; 
-              border-bottom: 2px solid #2563eb;
-              padding-bottom: 15px;
-            }
-            .round-info {
-              background: #f8fafc;
-              padding: 15px;
-              border-radius: 8px;
-              margin-bottom: 20px;
+            h1 {
+              text-align: center;
+              margin-bottom: 10px;
             }
             table { 
               width: 100%; 
@@ -139,14 +131,7 @@ export function MatchesTab({
           </style>
         </head>
         <body>
-          <div class="header">
-            <h1>Tour ${round}</h1>
-            <p>Tournoi de Pétanque - ${new Date().toLocaleDateString('fr-FR')}</p>
-          </div>
-          <div class="round-info">
-            <strong>Tour:</strong> ${round} • 
-            <strong>Nombre de matchs:</strong> ${roundMatches.length}
-          </div>
+          <h1>Tour ${round}</h1>
           <table>
             <thead>
               <tr>

--- a/src/components/StandingsTab.tsx
+++ b/src/components/StandingsTab.tsx
@@ -37,30 +37,16 @@ export function StandingsTab({ teams }: StandingsTabProps) {
       <!DOCTYPE html>
       <html>
         <head>
-          <title>Classement - Pétanque Manager</title>
+          <title>Résultats</title>
           <style>
-            body { 
-              font-family: Arial, sans-serif; 
-              margin: 20px; 
+            body {
+              font-family: Arial, sans-serif;
+              margin: 10px;
               color: #333;
             }
-            .header { 
-              text-align: center; 
-              margin-bottom: 30px; 
-              border-bottom: 2px solid #2563eb;
-              padding-bottom: 15px;
-            }
-            .logo {
-              width: 80px;
-              height: 80px;
-              margin: 0 auto 15px;
-              display: block;
-            }
-            .tournament-info {
-              background: #f8fafc;
-              padding: 15px;
-              border-radius: 8px;
-              margin-bottom: 20px;
+            h1 {
+              text-align: center;
+              margin-bottom: 10px;
             }
             table { 
               width: 100%; 
@@ -116,14 +102,7 @@ export function StandingsTab({ teams }: StandingsTabProps) {
           </style>
         </head>
         <body>
-          <div class="header">
-            <img src="/logo1.png" alt="Pétanque Manager" class="logo" />
-            <h1>🏆 Classement Final</h1>
-            <p>Tournoi de Pétanque - ${new Date().toLocaleDateString('fr-FR')}</p>
-          </div>
-          <div class="tournament-info">
-            <strong>Nombre ${isSolo ? 'de joueurs' : "d'équipes"}:</strong> ${teams.length}
-          </div>
+          <h1>Résultats</h1>
           <table>
             <thead>
               <tr>

--- a/src/components/TeamsTab.tsx
+++ b/src/components/TeamsTab.tsx
@@ -66,35 +66,21 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam }: Tea
       <!DOCTYPE html>
       <html>
         <head>
-          <title>Liste des ${isSolo ? 'Joueurs' : 'Équipes'} - Pétanque Manager</title>
+          <title>Liste des équipes</title>
           <style>
-            body { 
-              font-family: Arial, sans-serif; 
-              margin: 20px; 
+            body {
+              font-family: Arial, sans-serif;
+              margin: 10px;
               color: #333;
             }
-            .header { 
-              text-align: center; 
-              margin-bottom: 30px; 
-              border-bottom: 2px solid #2563eb;
-              padding-bottom: 15px;
+            h1 {
+              text-align: center;
+              margin-bottom: 10px;
             }
-            .logo {
-              width: 80px;
-              height: 80px;
-              margin: 0 auto 15px;
-              display: block;
-            }
-            .tournament-info {
-              background: #f8fafc;
-              padding: 15px;
-              border-radius: 8px;
-              margin-bottom: 20px;
-            }
-            .team-list { 
-              display: flex; 
-              flex-direction: column; 
-              gap: 15px; 
+            .team-list {
+              display: flex;
+              flex-direction: column;
+              gap: 15px;
             }
             .team-item { 
               border: 1px solid #e2e8f0; 
@@ -139,15 +125,7 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam }: Tea
           </style>
         </head>
         <body>
-          <div class="header">
-            <img src="/logo1.png" alt="Pétanque Manager" class="logo" />
-            <h1>🏆 Liste des ${isSolo ? 'Joueurs' : 'Équipes'}</h1>
-            <p>Tournoi de Pétanque - ${new Date().toLocaleDateString('fr-FR')}</p>
-          </div>
-          <div class="tournament-info">
-            <strong>Type:</strong> ${tournamentType.charAt(0).toUpperCase() + tournamentType.slice(1)} •
-            <strong>Nombre ${isSolo ? 'de joueurs' : "d'équipes"}:</strong> ${teams.length}
-          </div>
+          <h1>Liste des équipes</h1>
           <div class="team-list">
             ${teams.map(team => `
               <div class="team-item">


### PR DESCRIPTION
## Summary
- compress printed team list
- compact match round print layout
- shrink standings printout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853042e6f848324a1a3d1942298bbbf