### PR TITLE
Enhance print view layout

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -95,15 +95,20 @@ export function MatchesTab({
               text-align: center;
               margin-bottom: 10px;
             }
-            table { 
-              width: 100%; 
-              border-collapse: collapse; 
-              margin-top: 20px;
+            table {
+              width: 100%;
+              border-collapse: collapse;
+              margin-top: 10px;
             }
-            th, td { 
-              border: 1px solid #e2e8f0; 
-              padding: 12px; 
+            th, td {
+              padding: 8px;
               text-align: left;
+            }
+            tbody tr {
+              border-bottom: 1px solid #000;
+            }
+            tbody tr:last-child {
+              border-bottom: none;
             }
             th { 
               background: #f1f5f9; 

--- a/src/components/StandingsTab.tsx
+++ b/src/components/StandingsTab.tsx
@@ -48,15 +48,20 @@ export function StandingsTab({ teams }: StandingsTabProps) {
               text-align: center;
               margin-bottom: 10px;
             }
-            table { 
-              width: 100%; 
-              border-collapse: collapse; 
-              margin-top: 20px;
+            table {
+              width: 100%;
+              border-collapse: collapse;
+              margin-top: 10px;
             }
-            th, td { 
-              border: 1px solid #e2e8f0; 
-              padding: 12px; 
+            th, td {
+              padding: 8px;
               text-align: left;
+            }
+            tbody tr {
+              border-bottom: 1px solid #000;
+            }
+            tbody tr:last-child {
+              border-bottom: none;
             }
             th { 
               background: #f1f5f9; 

--- a/src/components/TeamsTab.tsx
+++ b/src/components/TeamsTab.tsx
@@ -80,14 +80,14 @@ export function TeamsTab({ teams, tournamentType, onAddTeam, onRemoveTeam }: Tea
             .team-list {
               display: flex;
               flex-direction: column;
-              gap: 15px;
+              gap: 4px;
             }
-            .team-item { 
-              border: 1px solid #e2e8f0; 
-              border-radius: 8px; 
-              padding: 15px; 
-              background: white;
-              box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            .team-item {
+              padding: 8px 0;
+              border-bottom: 1px solid #000;
+            }
+            .team-item:last-child {
+              border-bottom: none;
             }
             .team-name {
               font-weight: bold;


### PR DESCRIPTION
## Summary
- tighten spacing in printed team list and add separators
- add row separators and smaller padding in printed match table
- adjust printed standings table with thinner spacing and lines

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685306a5f2b08324a307161fb2b4d6ab