### PR TITLE
Update team labels for tête-à-tête

### DIFF
--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -42,7 +42,7 @@ export function useTournament() {
 
     const teamNumber = tournament.teams.length + 1;
     const teamName =
-      tournament.type === 'melee'
+      tournament.type === 'melee' || tournament.type === 'tete-a-tete'
         ? `${teamNumber} - ${players[0].name}`
         : `Équipe ${teamNumber}`;
 
@@ -72,7 +72,7 @@ export function useTournament() {
     const renumberedTeams = updatedTeams.map((team, index) => ({
       ...team,
       name:
-        tournament.type === 'melee'
+        tournament.type === 'melee' || tournament.type === 'tete-a-tete'
           ? `${index + 1} - ${team.players[0].name}`
           : `Équipe ${index + 1}`,
     }));


### PR DESCRIPTION
## Summary
- show player name instead of `Équipe N` for tête-à-tête tournaments

## Testing
- `npm run lint`
- `npm run build`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685322da178883248356afbc61dafd17