### PR TITLE
Fix melee BYE handling and spacing

### DIFF
--- a/src/components/MatchesTab.tsx
+++ b/src/components/MatchesTab.tsx
@@ -130,6 +130,9 @@ export function MatchesTab({
               font-weight: bold;
               text-align: left;
             }
+            .team-right {
+              padding-left: 20px;
+            }
             @media print {
               body { margin: 0; }
             }
@@ -156,7 +159,7 @@ export function MatchesTab({
                     ${!match.team1Ids ? `<br/><small>${getTeamPlayers(match.team1Id)}</small>` : ''}
                   </td>
                   <td class="score">${match.completed || match.isBye ? `${match.team1Score} - ${match.team2Score}` : '- - -'}</td>
-                  <td>
+                  <td class="team-right">
                     ${match.isBye ? 'BYE' : match.team2Ids ? getGroupLabel(match.team2Ids) : `${getTeamName(match.team2Id)}<br/><small>${getTeamPlayers(match.team2Id)}</small>`}
                   </td>
                   <td class="${match.completed || match.isBye ? 'status-completed' : 'status-pending'}">
@@ -249,7 +252,7 @@ export function MatchesTab({
                     <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                       Score
                     </th>
-                    <th className="px-8 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    <th className="pl-12 pr-8 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                       {isSolo ? 'Joueur' : 'Équipe'}
                     </th>
                     <th className="px-8 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
@@ -333,7 +336,7 @@ export function MatchesTab({
                           </span>
                         )}
                       </td>
-                      <td className="px-8 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
+                      <td className="pl-12 pr-8 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
                         {match.isBye ? (
                           <span className="text-gray-500 dark:text-gray-400 italic">BYE</span>
                         ) : match.team2Ids ? (

--- a/src/utils/matchmaking.ts
+++ b/src/utils/matchmaking.ts
@@ -274,13 +274,15 @@ function generateMeleeMatches(tournament: Tournament): Match[] {
     matchesResult.push({
       id: crypto.randomUUID(),
       round,
-      court: courtIndex,
+      court: 0,
       team1Id: teamIds[0],
       team2Id: teamIds[0],
       team1Ids: teamIds,
       team2Ids: teamIds,
-      completed: false,
-      isBye: false,
+      team1Score: 13,
+      team2Score: 7,
+      completed: true,
+      isBye: true,
     });
   }
 


### PR DESCRIPTION
## Summary
- tweak print table styles and UI spacing for the second team column
- mark remaining groups in mêlée rounds as BYE instead of pairing them with themselves

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853275755508324b777fc88f33bd86f