### PR TITLE
Remove background circle from logo

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,11 +11,9 @@ export function Header({ darkMode, onToggleDarkMode }: HeaderProps) {
   return (
     <header className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
       <div className="px-6 py-4 flex items-center justify-between">
-        <div className="flex items-center space-x-3">
-          <div className="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center overflow-hidden">
-            <Logo className="w-8 h-8" />
-          </div>
-          <div>
+          <div className="flex items-center space-x-3">
+            <Logo className="w-10 h-10" />
+            <div>
             <h1 className="text-xl font-bold text-gray-900 dark:text-white">
               Pétanque Manager
             </h1>


### PR DESCRIPTION
## Summary
- removed blue background circle from `Header` logo

## Testing
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*

------
https://chatgpt.com/codex/tasks/task_e_6855fd673dbc8324b15e725a0143a5b7