### PR TITLE
Fix lint setup and remove logo background

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.5.3",
+        "typescript-eslint": "^8.34.1",
         "vite": "^5.4.2",
         "wait-on": "^8.0.3"
       }
@@ -8352,6 +8353,29 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.34.1.tgz",
+      "integrity": "sha512-XjS+b6Vg9oT1BaIUfkW3M3LvqZE++rbzAMEHuccCfO/YkP43ha6w3jTEMilQxMF92nVOYCcdjv1ZUhAa1D/0ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.34.1",
+        "@typescript-eslint/parser": "8.34.1",
+        "@typescript-eslint/utils": "8.34.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
       "forceCodeSigning": false
     }
   },
-
   "dependencies": {
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
@@ -44,6 +43,8 @@
     "@eslint/js": "^9.9.1",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^8.3.0",
+    "@typescript-eslint/parser": "^8.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.18",
     "concurrently": "^9.1.2",
@@ -56,11 +57,9 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
-    "@typescript-eslint/parser": "^8.3.0",
-    "@typescript-eslint/eslint-plugin": "^8.3.0",
+    "typescript-eslint": "^8.34.1",
     "vite": "^5.4.2",
     "wait-on": "^8.0.3"
   },
   "license": "MIT"
 }
-

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,11 +11,9 @@ export function Header({ darkMode, onToggleDarkMode }: HeaderProps) {
   return (
     <header className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
       <div className="px-6 py-4 flex items-center justify-between">
-        <div className="flex items-center space-x-3">
-          <div className="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center overflow-hidden">
-            <Logo className="w-8 h-8" />
-          </div>
-          <div>
+          <div className="flex items-center space-x-3">
+            <Logo className="w-10 h-10" />
+            <div>
             <h1 className="text-xl font-bold text-gray-900 dark:text-white">
               Pétanque Manager
             </h1>


### PR DESCRIPTION
## Summary
- remove blue background circle from the logo in `Header`
- install `typescript-eslint` so `npm run lint` works again

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6855fd673dbc8324b15e725a0143a5b7