### PR TITLE
Remove blue circle from setup page

### DIFF
--- a/src/components/TournamentSetup.tsx
+++ b/src/components/TournamentSetup.tsx
@@ -28,8 +28,8 @@ export function TournamentSetup({ onCreateTournament }: TournamentSetupProps) {
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-4">
       <div className="max-w-2xl w-full">
         <div className="text-center mb-8">
-          <div className="w-16 h-16 bg-blue-600 rounded-full flex items-center justify-center mx-auto mb-4 overflow-hidden">
-            <Logo className="w-12 h-12" />
+          <div className="w-16 h-16 mx-auto mb-4">
+            <Logo className="w-16 h-16" />
           </div>
           <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
             Nouveau Tournoi de Pétanque


### PR DESCRIPTION
## Summary
- remove background circle from the setup page logo

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685605952214832484a6bd2c7d2fe272