### PR TITLE
Increase terrain options to 150

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.5.3",
+        "typescript-eslint": "^8.34.1",
         "vite": "^5.4.2",
         "wait-on": "^8.0.3"
       }
@@ -8352,6 +8353,29 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.34.1.tgz",
+      "integrity": "sha512-XjS+b6Vg9oT1BaIUfkW3M3LvqZE++rbzAMEHuccCfO/YkP43ha6w3jTEMilQxMF92nVOYCcdjv1ZUhAa1D/0ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.34.1",
+        "@typescript-eslint/parser": "8.34.1",
+        "@typescript-eslint/utils": "8.34.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
       "forceCodeSigning": false
     }
   },
-
   "dependencies": {
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
@@ -44,6 +43,8 @@
     "@eslint/js": "^9.9.1",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^8.3.0",
+    "@typescript-eslint/parser": "^8.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.18",
     "concurrently": "^9.1.2",
@@ -56,11 +57,9 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
-    "@typescript-eslint/parser": "^8.3.0",
-    "@typescript-eslint/eslint-plugin": "^8.3.0",
+    "typescript-eslint": "^8.34.1",
     "vite": "^5.4.2",
     "wait-on": "^8.0.3"
   },
   "license": "MIT"
 }
-

--- a/src/components/TournamentSetup.tsx
+++ b/src/components/TournamentSetup.tsx
@@ -89,10 +89,10 @@ export function TournamentSetup({ onCreateTournament }: TournamentSetupProps) {
               onChange={(e) => setCourts(Number(e.target.value))}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             >
-              {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(num => (
+              {Array.from({ length: 150 }, (_, i) => i + 1).map(num => (
                 <option key={num} value={num}>{num} terrain{num > 1 ? 's' : ''}</option>
               ))}
-            </select>
+              </select>
           </div>
 
           <button


### PR DESCRIPTION
## Summary
- allow selecting up to 150 terrains instead of 10
- add missing `typescript-eslint` dev dependency so lint can run

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685606c37ba083248f1601fe67917b0e