### PR TITLE
Add cyber theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,10 @@ src/
 
 To start the application in development mode run `npm run dev` as shown above.
 
+## Theme toggle
+
+The header provides two theme controls. The moon/sun button switches between
+light and dark modes. A lightning bolt button enables a "cyber" look by loading
+`public/theme-cyber-blue.css`. Both choices are saved in the browser so they
+persist across reloads.
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { RotateCcw } from 'lucide-react';
 
 function App() {
   const [darkMode, setDarkMode] = useState(false);
+  const [cyberTheme, setCyberTheme] = useState(false);
   const [activeTab, setActiveTab] = useState('teams');
   const {
     tournament,
@@ -28,6 +29,16 @@ function App() {
     if (savedDarkMode) {
       document.documentElement.classList.add('dark');
     }
+
+    const savedCyberTheme = localStorage.getItem('cyberTheme') === 'true';
+    setCyberTheme(savedCyberTheme);
+    if (savedCyberTheme) {
+      const link = document.createElement('link');
+      link.id = 'cyber-theme-link';
+      link.rel = 'stylesheet';
+      link.href = '/theme-cyber-blue.css';
+      document.head.appendChild(link);
+    }
   }, []);
 
   const toggleDarkMode = () => {
@@ -38,6 +49,24 @@ function App() {
       document.documentElement.classList.add('dark');
     } else {
       document.documentElement.classList.remove('dark');
+    }
+  };
+
+  const toggleCyberTheme = () => {
+    const newCyberTheme = !cyberTheme;
+    setCyberTheme(newCyberTheme);
+    localStorage.setItem('cyberTheme', String(newCyberTheme));
+    const existing = document.getElementById('cyber-theme-link');
+    if (newCyberTheme) {
+      if (!existing) {
+        const link = document.createElement('link');
+        link.id = 'cyber-theme-link';
+        link.rel = 'stylesheet';
+        link.href = '/theme-cyber-blue.css';
+        document.head.appendChild(link);
+      }
+    } else {
+      existing?.remove();
     }
   };
 
@@ -52,7 +81,12 @@ function App() {
   return (
     <div className={darkMode ? 'dark' : ''}>
       <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-        <Header darkMode={darkMode} onToggleDarkMode={toggleDarkMode} />
+        <Header
+          darkMode={darkMode}
+          onToggleDarkMode={toggleDarkMode}
+          cyberTheme={cyberTheme}
+          onToggleCyberTheme={toggleCyberTheme}
+        />
         
         <div className="bg-white dark:bg-gray-800 shadow-sm">
           <div className="px-6 py-4 flex justify-between items-center">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,12 +1,19 @@
-import { Sun, Moon } from 'lucide-react';
+import { Sun, Moon, Zap } from 'lucide-react';
 import { Logo } from './Logo';
 
 interface HeaderProps {
   darkMode: boolean;
   onToggleDarkMode: () => void;
+  cyberTheme: boolean;
+  onToggleCyberTheme: () => void;
 }
 
-export function Header({ darkMode, onToggleDarkMode }: HeaderProps) {
+export function Header({
+  darkMode,
+  onToggleDarkMode,
+  cyberTheme,
+  onToggleCyberTheme,
+}: HeaderProps) {
   return (
     <header className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
       <div className="px-6 py-4 flex items-center justify-between">
@@ -24,18 +31,27 @@ export function Header({ darkMode, onToggleDarkMode }: HeaderProps) {
           </div>
         </div>
 
-        {/* Bouton de bascule clair/sombre */}
-        <button
-          onClick={onToggleDarkMode}
-          className="p-2 rounded-lg bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
-          title={darkMode ? 'Mode clair' : 'Mode sombre'}
-        >
-          {darkMode ? (
-            <Sun className="w-5 h-5 text-gray-600 dark:text-gray-300" />
-          ) : (
-            <Moon className="w-5 h-5 text-gray-600 dark:text-gray-300" />
-          )}
-        </button>
+        {/* Boutons de thèmes */}
+        <div className="flex space-x-2">
+          <button
+            onClick={onToggleCyberTheme}
+            className={`p-2 rounded-lg bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors ${cyberTheme ? 'text-blue-600' : ''}`}
+            title="Thème cyber"
+          >
+            <Zap className="w-5 h-5 text-gray-600 dark:text-gray-300" />
+          </button>
+          <button
+            onClick={onToggleDarkMode}
+            className="p-2 rounded-lg bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+            title={darkMode ? 'Mode clair' : 'Mode sombre'}
+          >
+            {darkMode ? (
+              <Sun className="w-5 h-5 text-gray-600 dark:text-gray-300" />
+            ) : (
+              <Moon className="w-5 h-5 text-gray-600 dark:text-gray-300" />
+            )}
+          </button>
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- add cyber theme support in `App` via a link element
- expose cyber theme toggle in `Header`
- document theme toggles in README

## Testing
- `npm run lint`
- `npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_68571eec71bc832491951819ee3b7328