### PR TITLE
Remove dark mode feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ To start the application in development mode run `npm run dev` as shown above.
 
 ## Theme toggle
 
-The header provides two theme controls. The moon/sun button switches between
-light and dark modes. A lightning bolt button enables a "cyber" look by loading
-`public/theme-cyber-blue.css`. Both choices are saved in the browser so they
-persist across reloads.
+The header includes a single button with a lightning bolt icon. When pressed it
+applies a "cyber" look by loading `public/theme-cyber-blue.css`. This choice is
+stored in the browser so it persists across reloads.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,6 @@ import { useTournament } from './hooks/useTournament';
 import { RotateCcw } from 'lucide-react';
 
 function App() {
-  const [darkMode, setDarkMode] = useState(false);
   const [cyberTheme, setCyberTheme] = useState(false);
   const [activeTab, setActiveTab] = useState('teams');
   const {
@@ -24,29 +23,12 @@ function App() {
   } = useTournament();
 
   useEffect(() => {
-    const savedDarkMode = localStorage.getItem('darkMode') === 'true';
-    setDarkMode(savedDarkMode);
-    if (savedDarkMode) {
-      document.documentElement.classList.add('dark');
-    }
-
     const savedCyberTheme = localStorage.getItem('cyberTheme') === 'true';
     setCyberTheme(savedCyberTheme);
     if (savedCyberTheme) {
       document.documentElement.classList.add('cyber');
     }
   }, []);
-
-  const toggleDarkMode = () => {
-    const newDarkMode = !darkMode;
-    setDarkMode(newDarkMode);
-    localStorage.setItem('darkMode', String(newDarkMode));
-    if (newDarkMode) {
-      document.documentElement.classList.add('dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-    }
-  };
 
   const toggleCyberTheme = () => {
     const newCyberTheme = !cyberTheme;
@@ -116,11 +98,9 @@ function App() {
   );
 
   return (
-    <div className={darkMode ? 'dark' : ''}>
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div>
+      <div className="min-h-screen bg-gray-50">
         <Header
-          darkMode={darkMode}
-          onToggleDarkMode={toggleDarkMode}
           cyberTheme={cyberTheme}
           onToggleCyberTheme={toggleCyberTheme}
         />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,19 +1,12 @@
-import { Sun, Moon, Zap } from 'lucide-react';
+import { Zap } from 'lucide-react';
 import { Logo } from './Logo';
 
 interface HeaderProps {
-  darkMode: boolean;
-  onToggleDarkMode: () => void;
   cyberTheme: boolean;
   onToggleCyberTheme: () => void;
 }
 
-export function Header({
-  darkMode,
-  onToggleDarkMode,
-  cyberTheme,
-  onToggleCyberTheme,
-}: HeaderProps) {
+export function Header({ cyberTheme, onToggleCyberTheme }: HeaderProps) {
   return (
     <header className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
       <div className="px-6 py-4 flex items-center justify-between">
@@ -39,17 +32,6 @@ export function Header({
             title="Thème cyber"
           >
             <Zap className="w-5 h-5 text-gray-600 dark:text-gray-300" />
-          </button>
-          <button
-            onClick={onToggleDarkMode}
-            className="p-2 rounded-lg bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
-            title={darkMode ? 'Mode clair' : 'Mode sombre'}
-          >
-            {darkMode ? (
-              <Sun className="w-5 h-5 text-gray-600 dark:text-gray-300" />
-            ) : (
-              <Moon className="w-5 h-5 text-gray-600 dark:text-gray-300" />
-            )}
           </button>
         </div>
       </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,5 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- remove dark mode state and toggle
- keep only cyber theme button in the header
- remove dark mode reference from docs
- drop `darkMode` setting from Tailwind config

## Testing
- `npm run lint`
- `npm run build:web`

------
https://chatgpt.com/codex/tasks/task_e_68575e1c98e88324b7ac77ec037ccd48